### PR TITLE
update import directory of net/html

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	parser "code.google.com/p/go.net/html"
+	parser "golang.org/x/net/html"
 )
 
 // Sanitize utf8 html, allowing some tags


### PR DESCRIPTION
If I'm not mistaken, the `html` package has moved a few weeks ago to https://godoc.org/golang.org/x/net/html

This causes an error on one of my application's build step, so I'd be glad if you could consider to update the dependency path. I tested my repo after making the changes and it passed.
