### PR TITLE
Sanitize strings for base file names

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -212,6 +212,31 @@ func Name(text string) string {
 	return fileName
 }
 
+// Makes a string safe to use in a base file name
+func BaseName(text string) string {
+	// Start with lowercase string
+	fileName := strings.ToLower(text)
+	fileName = strings.Trim(fileName, " ")
+
+	// Replace certain joining characters with a dash
+	seps, err := regexp.Compile(`[ ./&_=+:]`)
+	if err == nil {
+		fileName = seps.ReplaceAllString(fileName, "-")
+	}
+
+	// Remove all other unrecognised characters - NB we do allow any printable characters
+	legal, err := regexp.Compile(`[^[:alnum:]-]`)
+	if err == nil {
+		fileName = legal.ReplaceAllString(fileName, "")
+	}
+
+	// Remove any double dashes caused by existing - in name
+	fileName = strings.Replace(fileName, "--", "-", -1)
+
+	// NB this may be of length 0, caller must check
+	return fileName
+}
+
 // Replace a set of accented characters with ascii equivalents.
 func Accents(text string) string {
 	// Replace some common accent characters

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -50,6 +50,21 @@ func TestName(t *testing.T) {
 	}
 }
 
+var baseFileNames = []Test{
+	{"And/Or", `and-or`},
+	{"sonic.exe", `sonic-exe`},
+	{"012: #fetch for Defaults", `012-fetch-for-defaults`},
+}
+
+func TestBaseName(t *testing.T) {
+	for _, test := range baseFileNames {
+		output := BaseName(test.input)
+		if output != test.expected {
+			t.Fatalf(Format, test.input, test.expected, output)
+		}
+	}
+}
+
 // Test with some malformed or malicious html
 // NB because we remove all tokens after a < until the next >
 // and do not attempt to parse, we should be safe from invalid html,


### PR DESCRIPTION
Allow for strings with `/` or `.` to be sanitized used for a base file name.