### PR TITLE
Allow hash hrefs

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -308,7 +308,7 @@ var (
 	illegalAttr = regexp.MustCompile(`(d\s*a\s*t\s*a|j\s*a\s*v\s*a\s*s\s*c\s*r\s*i\s*p\s*t\s*)\s*:`)
 
 	// We are far more restrictive with href attributes.
-	legalHrefAttr = regexp.MustCompile(`\A/[^/\\]?|mailto://|http://|https://`)
+	legalHrefAttr = regexp.MustCompile(`\A[/#][^/\\]?|mailto://|http://|https://`)
 )
 
 // cleanAttributes returns an array of attributes after removing malicious ones.

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -173,6 +173,7 @@ var htmlTestsAllowing = []Test{
 		`<a href="http://www.google.com/"><img src="https://ssl.gstatic.com/accounts/ui/logo_2x.png"/></a>`},
 	{`<a href="javascript:alert(&#39;XSS1&#39;)" "document.write('<HTML> Tags and markup');">XSS<a>`, `<a> Tags and markup&#39;);&#34;&gt;XSS<a>`},
 	{`<a <script>document.write("UNTRUSTED INPUT: " + document.location.hash);<script/> >`, `<a>document.write(&#34;UNTRUSTED INPUT: &#34; + document.location.hash); &gt;`},
+	{`<a href="#anchor">foo</a>`, `<a href="#anchor">foo</a>`},
 	{`<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>`, `<img>`},
 	{`<IMG SRC="jav	ascript:alert('XSS');">`, `<img>`},
 	{`<IMG SRC="jav&#x09;ascript:alert('XSS');">`, `<img>`},


### PR DESCRIPTION
This makes it so sanitize doesn't strip away hash URLs in the `a.href` attribute.