### PR TITLE
Don't require // for the mailto: scheme

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -307,7 +307,7 @@ var (
 	illegalAttr = regexp.MustCompile(`(d\s*a\s*t\s*a|j\s*a\s*v\s*a\s*s\s*c\s*r\s*i\s*p\s*t\s*)\s*:`)
 
 	// We are far more restrictive with href attributes.
-	legalHrefAttr = regexp.MustCompile(`\A[/#][^/\\]?|mailto://|http://|https://`)
+	legalHrefAttr = regexp.MustCompile(`\A[/#][^/\\]?|mailto:|http://|https://`)
 )
 
 // cleanAttributes returns an array of attributes after removing malicious ones.

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -203,6 +203,7 @@ var htmlTestsAllowing = []Test{
 	{`<IMG """><SCRIPT>alert("XSS")</SCRIPT>">`, `<img>&#34;&gt;`},
 	{`<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&
 #0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>`, `<img>`},
+	{`<a href="mailto:cool@test.com?subject=cooool">cool guy</a>`, `<a href="mailto:cool@test.com?subject=cooool">cool guy</a>`},
 }
 
 func TestHTMLAllowed(t *testing.T) {


### PR DESCRIPTION
Mailto links have the form ```<a href="mailto:test@example.com">...</a>``` with no // after the colon. This removes the // from the expression to make mailto: href attributes work correctly.